### PR TITLE
Make DataSet closesable, the same as storage and whole Snapper

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,6 +13,7 @@ android {
     }
 
     packagingOptions {
+        exclude 'LICENSE'
         exclude 'LICENSE.txt'
     }
 }
@@ -30,6 +31,9 @@ dependencies {
     compile 'com.esotericsoftware:kryo:3.0.0'
     //
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
+    androidTestCompile 'org.mockito:mockito-core:2.0.5-beta'
+    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'com.artfulbits:meter:1.0.1.141'
 }
 

--- a/library/src/androidTest/java/io/techery/snapper/BaseTestCase.java
+++ b/library/src/androidTest/java/io/techery/snapper/BaseTestCase.java
@@ -7,16 +7,17 @@ import android.support.test.runner.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import io.techery.snapper.snappydb.SnappyComponentFactory;
 import io.techery.snapper.storage.DatabaseFactory;
+import io.techery.snapper.util.SimpleExecutorService;
 
 @RunWith(AndroidJUnit4.class)
 public class BaseTestCase {
 
     protected Snapper db;
-    protected Executor executor = new Executor() {
+    protected ExecutorService executor = new SimpleExecutorService() {
         @Override public void execute(Runnable command) {
             command.run();
         }
@@ -31,11 +32,11 @@ public class BaseTestCase {
         DatabaseFactory databaseFactory = snapperBuilder.useDefaultDatabaseFactory("snappydb_test");
         db = snapperBuilder.componentFactory(new SnappyComponentFactory(databaseFactory) {
 
-            @Override public Executor createStorageExecutor() {
+            @Override public ExecutorService createStorageExecutor() {
                 return executor;
             }
 
-            @Override public Executor createCollectionExecutor() {
+            @Override public ExecutorService createCollectionExecutor() {
                 return executor;
             }
         }).build();

--- a/library/src/androidTest/java/io/techery/snapper/test/BasicOperationsTest.java
+++ b/library/src/androidTest/java/io/techery/snapper/test/BasicOperationsTest.java
@@ -1,16 +1,14 @@
 package io.techery.snapper.test;
 
-import android.support.test.runner.AndroidJUnit4;
-
-import com.innahema.collections.query.functions.Converter;
 import com.innahema.collections.query.functions.Function1;
 import com.innahema.collections.query.functions.Predicate;
 import com.innahema.collections.query.queriables.Queryable;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.rules.ExpectedException;
 
 import java.util.Comparator;
 import java.util.List;
@@ -18,21 +16,25 @@ import java.util.List;
 import io.techery.snapper.BaseTestCase;
 import io.techery.snapper.DataCollection;
 import io.techery.snapper.dataset.DataSetMap;
-import io.techery.snapper.model.ItemRef;
+import io.techery.snapper.dataset.IDataSet.StatusListener;
 import io.techery.snapper.model.User;
+import io.techery.snapper.util.ModelUtil;
 import io.techery.snapper.view.DataViewBuilder;
 import io.techery.snapper.view.IDataView;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.matchers.JUnitMatchers.hasItem;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
 
-@RunWith(AndroidJUnit4.class)
 public class BasicOperationsTest extends BaseTestCase {
 
     DataCollection<User> dataCollection;
-    IDataView<User> filtered;
+    IDataView<User> filteredDataView;
 
     ///////////////////////////////////////////////////////////////////////////
     // Preconditions
@@ -41,14 +43,7 @@ public class BasicOperationsTest extends BaseTestCase {
     @Before
     public void createCollectionAndFilter() {
         dataCollection = db.collection(User.class);
-
-        dataCollection.insert(new User("10000"));
-        dataCollection.insert(new User("100"));
-        dataCollection.insert(new User("1"));
-        dataCollection.insert(new User("10"));
-        dataCollection.insert(new User("1000"));
-
-        filtered = dataCollection.view()
+        filteredDataView = dataCollection.view()
                 .where(new Predicate<User>() {
                     @Override
                     public boolean apply(User element) {
@@ -65,7 +60,10 @@ public class BasicOperationsTest extends BaseTestCase {
 
     @After
     public void releaseCollection() throws Exception {
-        dataCollection.clear();
+        if (!dataCollection.isClosed()) {
+            dataCollection.clear();
+            dataCollection.close();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -73,7 +71,16 @@ public class BasicOperationsTest extends BaseTestCase {
     ///////////////////////////////////////////////////////////////////////////
 
     @Test
-    public void testWhere() {
+    public void loadCollection() {
+        dataCollection.insertAll(ModelUtil.generateUsers(1000));
+        dataCollection.close();
+        dataCollection = db.collection(User.class);
+        assertThat(Queryable.from(dataCollection).count(), is(1000));
+    }
+
+    @Test
+    public void buildFilteredDataView() {
+        insertUsers();
         IDataView<User> filtered = dataCollection.view().where(new Predicate<User>() {
             @Override
             public boolean apply(User element) {
@@ -85,7 +92,8 @@ public class BasicOperationsTest extends BaseTestCase {
     }
 
     @Test
-    public void testSort() {
+    public void buildSortedDataView() {
+        insertUsers();
         IDataView<User> sorted = dataCollection.view().sort(new Comparator<User>() {
             @Override
             public int compare(User o1, User o2) {
@@ -102,26 +110,29 @@ public class BasicOperationsTest extends BaseTestCase {
     }
 
     @Test
-    public void testAdd() {
+    public void addOne() {
+        insertUsers();
         dataCollection.insert(new User("100000"));
 
-        assertThat("Filtered DataView should have 3 elements with length > 3", filtered.size(), is(3));
-        List<String> ids = extractUserIds(filtered);
+        assertThat("Filtered DataView should have 3 elements with length > 3", filteredDataView.size(), is(3));
+        List<String> ids = ModelUtil.extractUserIds(filteredDataView);
         assertThat(ids, hasItem("1000"));
         assertThat(ids, hasItem("10000"));
         assertThat(ids, hasItem("100000"));
     }
 
     @Test
-    public void testRemove() {
+    public void removeOne() {
+        insertUsers();
         dataCollection.remove(new User("1000"));
 
-        assertThat("should have 2 elements", filtered.size(), is(1));
-        assertThat(filtered.getItem(0).getUserId(), equalTo("10000"));
+        assertThat("should have 2 elements", filteredDataView.size(), is(1));
+        assertThat(filteredDataView.getItem(0).getUserId(), equalTo("10000"));
     }
 
     @Test
-    public void testUpdate() {
+    public void updateOne() {
+        insertUsers();
         IDataView<User> filtered = dataCollection.view()
                 .where(new Predicate<User>() {
                     @Override
@@ -137,20 +148,19 @@ public class BasicOperationsTest extends BaseTestCase {
                 .build();
 
         String userId = "1000";
-        List<String> ids;
 
         dataCollection.insert(new User(userId, 10));
-        ids = extractUserIds(filtered);
         assertThat("Filtered DataView should have 0 elements with age > 100", filtered.size(), is(0));
 
         dataCollection.insert(new User(userId, 400));
-        ids = extractUserIds(filtered);
+        List<String> ids = ModelUtil.extractUserIds(filtered);
         assertThat("Filtered DataView should have 1 elements with age > 100", filtered.size(), is(1));
         assertThat(ids, hasItem(userId));
     }
 
     @Test
-    public void testMap() {
+    public void buildMappedDataSet() {
+        insertUsers();
         DataSetMap<User, Integer> dataSetMap = new DataSetMap<User, Integer>(dataCollection, new Function1<User, Integer>() {
             @Override
             public Integer apply(User s) {
@@ -178,16 +188,45 @@ public class BasicOperationsTest extends BaseTestCase {
         assertThat("should have 5 elements", dv.size(), is(6));
     }
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void closeAll() {
+        db.close();
+        assertTrue(dataCollection.isClosed());
+        assertTrue(filteredDataView.isClosed());
+    }
+
+    @Test
+    public void collectionAfterClose() {
+        db.close();
+        thrown.expect(IllegalStateException.class);
+        dataCollection.insert(new User("123123"));
+    }
+
+    @Test
+    public void dataViewAfterClose() {
+        StatusListener mockListener = mock(StatusListener.class);
+        filteredDataView.addStatusListener(mockListener);
+        db.close();
+        verify(mockListener, only()).onClosed();
+        //
+        thrown.expect(IllegalStateException.class);
+        filteredDataView.toList();
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     // Helpers
     ///////////////////////////////////////////////////////////////////////////
 
-    private List<String> extractUserIds(Iterable<ItemRef<User>> source) {
-        return Queryable.from(source).map(new Converter<ItemRef<User>, String>() {
-            @Override public String convert(ItemRef<User> element) {
-                return element.getValue().getUserId();
-            }
-        }).toList();
+    private void insertUsers() {
+        dataCollection.insert(new User("10000"));
+        dataCollection.insert(new User("100"));
+        dataCollection.insert(new User("1"));
+        dataCollection.insert(new User("10"));
+        dataCollection.insert(new User("1000"));
     }
+
 
 }

--- a/library/src/androidTest/java/io/techery/snapper/test/ManyCollectionsTest.java
+++ b/library/src/androidTest/java/io/techery/snapper/test/ManyCollectionsTest.java
@@ -5,7 +5,6 @@ import android.support.test.runner.AndroidJUnit4;
 import com.innahema.collections.query.functions.Predicate;
 import com.innahema.collections.query.queriables.Queryable;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +18,9 @@ import io.techery.snapper.model.Company;
 import io.techery.snapper.model.User;
 import io.techery.snapper.view.IDataView;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.matchers.JUnitMatchers.hasItem;
 
 @RunWith(AndroidJUnit4.class)
@@ -46,8 +47,8 @@ public class ManyCollectionsTest extends BaseTestCase {
     }
 
     @After public void releaseCollection() throws Exception {
-        userStorage.clear();
-        companyStorage.clear();
+        if (!userStorage.isClosed()) userStorage.clear();
+        if (!companyStorage.isClosed()) companyStorage.clear();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -55,8 +56,8 @@ public class ManyCollectionsTest extends BaseTestCase {
     ///////////////////////////////////////////////////////////////////////////
 
     @Test public void storageConsistency() {
-        assertThat(userStorage.view().build().toList().size(), CoreMatchers.is(5));
-        assertThat(companyStorage.view().build().toList().size(), CoreMatchers.is(2));
+        assertThat(userStorage.view().build().toList().size(), is(5));
+        assertThat(companyStorage.view().build().toList().size(), is(2));
     }
 
     @Test public void modelEqualityFromDiffStorages() {
@@ -73,6 +74,12 @@ public class ManyCollectionsTest extends BaseTestCase {
         Company company = Queryable.from(smallCoView.toList()).first();
         User user = Queryable.from(smallCoUserView.toList()).first();
         assertThat(company.getUsers(), hasItem(user));
+    }
+
+    @Test public void closeAll() {
+        db.close();
+        assertTrue(userStorage.isClosed());
+        assertTrue(companyStorage.isClosed());
     }
 
 }

--- a/library/src/androidTest/java/io/techery/snapper/test/benchmark/SpeedDataViewTest.java
+++ b/library/src/androidTest/java/io/techery/snapper/test/benchmark/SpeedDataViewTest.java
@@ -18,8 +18,8 @@ public class SpeedDataViewTest extends SpeedTest {
         views = new ArrayList<>();
         for (int i = 0; i < DATA_VIEW_COUNT; i++) {
             IDataView<User> view = userStorage.view().build();
-            view.addListener(new IDataSet.Listener<User>() {
-                @Override public void onDataSetUpdated(IDataSet<User> dataSet, StorageChange<User> change) {
+            view.addDataListener(new IDataSet.DataListener<User>() {
+                @Override public void onDataUpdated(IDataSet<User> dataSet, StorageChange<User> change) {
                     if (canMeterChange(change)) METER.beat("View updated with " + change);
                 }
             });

--- a/library/src/androidTest/java/io/techery/snapper/test/benchmark/SpeedTest.java
+++ b/library/src/androidTest/java/io/techery/snapper/test/benchmark/SpeedTest.java
@@ -34,8 +34,8 @@ public class SpeedTest extends BaseTestCase {
     @Before
     public void initStorage() {
         userStorage = db.collection(User.class);
-        userStorage.addListener(new IDataSet.Listener<User>() {
-            @Override public void onDataSetUpdated(IDataSet<User> dataSet, StorageChange<User> change) {
+        userStorage.addDataListener(new IDataSet.DataListener<User>() {
+            @Override public void onDataUpdated(IDataSet<User> dataSet, StorageChange<User> change) {
                 if (canMeterChange(change)) METER.beat("Storage updated with " + change);
             }
         });

--- a/library/src/androidTest/java/io/techery/snapper/util/ModelUtil.java
+++ b/library/src/androidTest/java/io/techery/snapper/util/ModelUtil.java
@@ -1,0 +1,34 @@
+package io.techery.snapper.util;
+
+import com.innahema.collections.query.functions.Converter;
+import com.innahema.collections.query.queriables.Queryable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import io.techery.snapper.model.ItemRef;
+import io.techery.snapper.model.User;
+
+public class ModelUtil {
+
+    private ModelUtil(){}
+
+    public static List<User> generateUsers(int batchSize) {
+        List<User> users = new ArrayList<User>();
+        Random randomSource = new Random(batchSize);
+        for (int i = 0; i < batchSize; i++) {
+            int random = randomSource.nextInt();
+            users.add(new User(String.valueOf(i), random / 2));
+        }
+        return users;
+    }
+
+    public static List<String> extractUserIds(Iterable<ItemRef<User>> source) {
+        return Queryable.from(source).map(new Converter<ItemRef<User>, String>() {
+            @Override public String convert(ItemRef<User> element) {
+                return element.getValue().getUserId();
+            }
+        }).toList();
+    }
+}

--- a/library/src/main/java/io/techery/snapper/ComponentFactory.java
+++ b/library/src/main/java/io/techery/snapper/ComponentFactory.java
@@ -1,7 +1,7 @@
 package io.techery.snapper;
 
 import java.io.IOException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import io.techery.snapper.converter.ObjectConverter;
 import io.techery.snapper.model.Indexable;
@@ -11,6 +11,6 @@ public interface ComponentFactory {
 
     DatabaseAdapter createDatabase(String simpleName) throws IOException;
     <T extends Indexable> ObjectConverter<T> createConverter(Class<T> className);
-    Executor createStorageExecutor();
-    Executor createCollectionExecutor();
+    ExecutorService createStorageExecutor();
+    ExecutorService createCollectionExecutor();
 }

--- a/library/src/main/java/io/techery/snapper/Snapper.java
+++ b/library/src/main/java/io/techery/snapper/Snapper.java
@@ -31,6 +31,9 @@ public class Snapper {
                 dataCollection = dataCollectionCache.get(className);
                 if (dataCollection == null || dataCollection.isClosed()) {
                     try {
+                        if (dataCollection != null) {
+                            collectionStorageCache.remove(dataCollection);
+                        }
                         Storage<T> storage = storageFactory.createStorage(className);
                         Executor executor = componentFactory.createCollectionExecutor();
                         dataCollection = new DataCollection<>(storage, executor);

--- a/library/src/main/java/io/techery/snapper/Snapper.java
+++ b/library/src/main/java/io/techery/snapper/Snapper.java
@@ -3,8 +3,10 @@ package io.techery.snapper;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 import io.techery.snapper.model.Indexable;
+import io.techery.snapper.storage.Storage;
 import io.techery.snapper.storage.StorageFactory;
 
 public class Snapper {
@@ -12,33 +14,55 @@ public class Snapper {
     private final StorageFactory storageFactory;
     private final ComponentFactory componentFactory;
     private final Map<Class<? extends Indexable>, DataCollection> dataCollectionCache;
+    private final Map<DataCollection, Storage> collectionStorageCache;
 
     public Snapper(StorageFactory storageFactory, ComponentFactory componentFactory) {
         this.storageFactory = storageFactory;
         this.componentFactory = componentFactory;
         this.dataCollectionCache = new HashMap<>();
+        this.collectionStorageCache = new HashMap<>();
     }
 
     public <T extends Indexable> DataCollection<T> collection(Class<T> className) {
         DataCollection<T> dataCollection = dataCollectionCache.get(className);
-        if (dataCollection == null) {
+        if (dataCollection == null || dataCollection.isClosed()) {
             // Double check not to create duplicates from sep. threads
             synchronized (Snapper.class) {
                 dataCollection = dataCollectionCache.get(className);
-                if (dataCollection == null) {
+                if (dataCollection == null || dataCollection.isClosed()) {
                     try {
-                        dataCollection = new DataCollection<>(
-                                storageFactory.createStorage(className),
-                                componentFactory.createCollectionExecutor()
-                        );
+                        Storage<T> storage = storageFactory.createStorage(className);
+                        Executor executor = componentFactory.createCollectionExecutor();
+                        dataCollection = new DataCollection<>(storage, executor);
+                        //
+                        dataCollectionCache.put(className, dataCollection);
+                        collectionStorageCache.put(dataCollection, storage);
                     } catch (IOException e) {
                         e.printStackTrace();
                         return null;
                     }
-                    dataCollectionCache.put(className, dataCollection);
                 }
             }
         }
         return dataCollection;
+    }
+
+    public void clear() {
+        synchronized (Snapper.class) {
+            for (DataCollection dataCollection : collectionStorageCache.keySet()) {
+                dataCollection.clear();
+            }
+        }
+    }
+
+    public void close() {
+        synchronized (Snapper.class) {
+            for (DataCollection collection : collectionStorageCache.keySet()) {
+                Storage storage = collectionStorageCache.get(collection);
+                storage.close();
+                collection.close();
+            }
+            collectionStorageCache.clear();
+        }
     }
 }

--- a/library/src/main/java/io/techery/snapper/dataset/DataSet.java
+++ b/library/src/main/java/io/techery/snapper/dataset/DataSet.java
@@ -7,31 +7,51 @@ import io.techery.snapper.storage.StorageChange;
 
 public abstract class DataSet<T> implements IDataSet<T> {
 
-    private final List<Listener<T>> listeners = new CopyOnWriteArrayList<>();
+    ///////////////////////////////////////////////////////////////////////////
+    // Data
+    ///////////////////////////////////////////////////////////////////////////
+
+    private final List<DataListener<T>> dataListeners = new CopyOnWriteArrayList<DataListener<T>>();
 
     @Override
-    public void addListener(final Listener<T> listener) {
-        listeners.add(listener);
+    public void addDataListener(final DataListener<T> listener) {
+        dataListeners.add(listener);
         perform(new Runnable() {
             @Override
             public void run() {
-                listener.onDataSetUpdated(DataSet.this, StorageChange.<T>empty());
+                listener.onDataUpdated(DataSet.this, StorageChange.<T>empty());
             }
         });
     }
 
     @Override
-    public void removeListener(final Listener<T> listener) {
-        listeners.remove(listener);
-    }
-
-    protected void clearListeners() {
-        listeners.clear();
+    public void removeDataListener(final DataListener<T> listener) {
+        dataListeners.remove(listener);
     }
 
     protected void didUpdateDataSet(final StorageChange<T> change) {
-        for (final Listener<T> listener : listeners) {
-            listener.onDataSetUpdated(this, change);
+        for (DataListener<T> listener : dataListeners) {
+            listener.onDataUpdated(this, change);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Status
+    ///////////////////////////////////////////////////////////////////////////
+
+    private final List<StatusListener> statusListeners = new CopyOnWriteArrayList<StatusListener>();
+
+    @Override public void addStatusListener(StatusListener listener) {
+        statusListeners.add(listener);
+    }
+
+    @Override public void removeStatusListener(StatusListener listener) {
+
+    }
+
+    protected void didClose() {
+        for (StatusListener listener : statusListeners) {
+            listener.onClosed();
         }
     }
 

--- a/library/src/main/java/io/techery/snapper/dataset/DataSetMap.java
+++ b/library/src/main/java/io/techery/snapper/dataset/DataSetMap.java
@@ -4,23 +4,31 @@ import com.innahema.collections.query.functions.Converter;
 import com.innahema.collections.query.functions.Function1;
 import com.innahema.collections.query.queriables.Queryable;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.techery.snapper.model.ItemRef;
 import io.techery.snapper.storage.StorageChange;
 
-public class DataSetMap<F, T> implements IDataSet<T>, IDataSet.Listener<F> {
+public class DataSetMap<F, T> implements IDataSet<T>, IDataSet.DataListener<F> {
 
     private final IDataSet<F> originalDataSet;
     private final Function1<F, T> mapFunction;
-    private final List<Listener<T>> listeners = new ArrayList<Listener<T>>();
+    private final List<DataListener<T>> listeners = new CopyOnWriteArrayList<DataListener<T>>();
 
     public DataSetMap(IDataSet<F> originalDataSet, Function1<F, T> mapFunction) {
         this.originalDataSet = originalDataSet;
         this.mapFunction = mapFunction;
-        this.originalDataSet.addListener(this);
+        this.originalDataSet.addDataListener(this);
+    }
+
+    @Override public void close() {
+        throw new UnsupportedOperationException("Transmitter set couldn't be closed directly");
+    }
+
+    @Override public boolean isClosed() {
+        return originalDataSet.isClosed();
     }
 
     @Override
@@ -46,13 +54,23 @@ public class DataSetMap<F, T> implements IDataSet<T>, IDataSet.Listener<F> {
     }
 
     @Override
-    public void addListener(final Listener<T> listener) {
+    public void addDataListener(final DataListener<T> listener) {
         this.listeners.add(listener);
     }
 
     @Override
-    public void removeListener(Listener<T> listener) {
+    public void removeDataListener(DataListener<T> listener) {
         this.listeners.remove(listener);
+    }
+
+    @Override
+    public void addStatusListener(StatusListener listener) {
+        originalDataSet.addStatusListener(listener);
+    }
+
+    @Override
+    public void removeStatusListener(StatusListener listener) {
+        originalDataSet.removeStatusListener(listener);
     }
 
     @Override
@@ -61,25 +79,24 @@ public class DataSetMap<F, T> implements IDataSet<T>, IDataSet.Listener<F> {
     }
 
     @Override
-    public void onDataSetUpdated(IDataSet<F> dataSet, StorageChange<F> change) {
+    public void onDataUpdated(IDataSet<F> dataSet, StorageChange<F> change) {
         final StorageChange<T> mappedChange = mapChange(change);
-        for (Listener<T> listener : listeners) {
-            listener.onDataSetUpdated(this, mappedChange);
+        for (DataListener<T> listener : listeners) {
+            listener.onDataUpdated(this, mappedChange);
         }
     }
 
     private StorageChange<T> mapChange(StorageChange<F> change) {
-
-        final Converter<ItemRef<F>, ItemRef<T>> converter = new Converter<ItemRef<F>, ItemRef<T>>() {
+        Converter<ItemRef<F>, ItemRef<T>> converter = new Converter<ItemRef<F>, ItemRef<T>>() {
             @Override
             public ItemRef<T> convert(ItemRef<F> element) {
                 return new ItemRef<T>(element.getKey(), mapFunction.apply(element.getValue()));
             }
         };
 
-        final List<ItemRef<T>> added = Queryable.from(change.getAdded()).map(converter).toList();
-        final List<ItemRef<T>> removed = Queryable.from(change.getRemoved()).map(converter).toList();
-        final List<ItemRef<T>> updated = Queryable.from(change.getUpdated()).map(converter).toList();
+        List<ItemRef<T>> added = Queryable.from(change.getAdded()).map(converter).toList();
+        List<ItemRef<T>> removed = Queryable.from(change.getRemoved()).map(converter).toList();
+        List<ItemRef<T>> updated = Queryable.from(change.getUpdated()).map(converter).toList();
 
         return new StorageChange<T>(added, updated, removed);
     }

--- a/library/src/main/java/io/techery/snapper/dataset/IDataSet.java
+++ b/library/src/main/java/io/techery/snapper/dataset/IDataSet.java
@@ -5,13 +5,25 @@ import io.techery.snapper.storage.StorageChange;
 
 public interface IDataSet<T> extends Iterable<ItemRef<T>> {
 
-    public interface Listener<T> {
-        void onDataSetUpdated(IDataSet<T> dataSet, StorageChange<T> change);
+    interface DataListener<T> {
+        void onDataUpdated(IDataSet<T> dataSet, StorageChange<T> change);
     }
 
-    public void addListener(Listener<T> listener);
+    void addDataListener(DataListener<T> listener);
 
-    public void removeListener(Listener<T> listener);
+    void removeDataListener(DataListener<T> listener);
 
-    public void perform(Runnable runnable);
+    interface StatusListener {
+        void onClosed();
+    }
+
+    void addStatusListener(StatusListener listener);
+
+    void removeStatusListener(StatusListener listener);
+
+    void close();
+
+    boolean isClosed();
+
+    void perform(Runnable runnable);
 }

--- a/library/src/main/java/io/techery/snapper/listadapter/DataViewListAdapter.java
+++ b/library/src/main/java/io/techery/snapper/listadapter/DataViewListAdapter.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 import io.techery.snapper.dataset.IDataSet;
 import io.techery.snapper.storage.StorageChange;
-import io.techery.snapper.util.android.MainThreadListenerProxy;
+import io.techery.snapper.util.android.MainThreadDataListenerProxy;
 import io.techery.snapper.view.IDataView;
 
-public class DataViewListAdapter<T> extends ArrayAdapter<T> implements IDataSet.Listener<T> {
+public class DataViewListAdapter<T> extends ArrayAdapter<T> implements IDataSet.DataListener<T> {
 
     static final String TAG = DataViewListAdapter.class.getSimpleName();
 
@@ -28,15 +28,15 @@ public class DataViewListAdapter<T> extends ArrayAdapter<T> implements IDataSet.
 
     public void setDataView(IDataView<T> dataView) {
         if (this.dataView != null) {
-            this.dataView.removeListener(this);
+            this.dataView.removeDataListener(this);
         }
 
         this.dataView = dataView;
-        this.dataView.addListener(new MainThreadListenerProxy<T>(this));
+        this.dataView.addDataListener(new MainThreadDataListenerProxy<T>(this));
     }
 
     @Override
-    public void onDataSetUpdated(final IDataSet<T> dataSet, StorageChange<T> change) {
+    public void onDataUpdated(final IDataSet<T> dataSet, StorageChange<T> change) {
         syncWithDataView();
         notifyDataSetChanged();
     }

--- a/library/src/main/java/io/techery/snapper/snappydb/SnappyStorageFactory.java
+++ b/library/src/main/java/io/techery/snapper/snappydb/SnappyStorageFactory.java
@@ -1,7 +1,7 @@
 package io.techery.snapper.snappydb;
 
 import java.io.IOException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import io.techery.snapper.ComponentFactory;
 import io.techery.snapper.converter.ObjectConverter;
@@ -22,7 +22,7 @@ public class SnappyStorageFactory implements StorageFactory {
     public <T extends Indexable> Storage<T> createStorage(Class<T> className) throws IOException {
         DatabaseAdapter databaseAdapter = this.componentFactory.createDatabase(className.getSimpleName());
         ObjectConverter<T> objectConverter = this.componentFactory.createConverter(className);
-        Executor executor = this.componentFactory.createStorageExecutor();
+        ExecutorService executor = this.componentFactory.createStorageExecutor();
 
         return new PersistentStorage<>(databaseAdapter, objectConverter, executor);
     }

--- a/library/src/main/java/io/techery/snapper/storage/Storage.java
+++ b/library/src/main/java/io/techery/snapper/storage/Storage.java
@@ -7,7 +7,7 @@ import io.techery.snapper.model.ItemRef;
 
 public interface Storage<T> {
 
-    public interface UpdateCallback<T> {
+    interface UpdateCallback<T> {
         void onStorageUpdate(StorageChange<T> storageChange);
     }
 
@@ -22,4 +22,6 @@ public interface Storage<T> {
     Set<ItemRef<T>> items();
 
     void clear(UpdateCallback<T> updateCallback);
+    
+    void close();
 }

--- a/library/src/main/java/io/techery/snapper/util/SimpleExecutorService.java
+++ b/library/src/main/java/io/techery/snapper/util/SimpleExecutorService.java
@@ -1,0 +1,32 @@
+package io.techery.snapper.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public abstract class SimpleExecutorService extends AbstractExecutorService {
+
+    private volatile boolean isShutDown;
+
+    @Override public synchronized void shutdown() {
+        isShutDown = true;
+    }
+
+    @Override public synchronized List<Runnable> shutdownNow() {
+        isShutDown = true;
+        return Collections.emptyList();
+    }
+
+    @Override public synchronized boolean isShutdown() {
+        return isShutDown;
+    }
+
+    @Override public synchronized boolean isTerminated() {
+        return isShutDown;
+    }
+
+    @Override public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return isShutDown;
+    }
+}

--- a/library/src/main/java/io/techery/snapper/util/android/MainThreadDataListenerProxy.java
+++ b/library/src/main/java/io/techery/snapper/util/android/MainThreadDataListenerProxy.java
@@ -8,25 +8,25 @@ import java.lang.ref.WeakReference;
 import io.techery.snapper.dataset.IDataSet;
 import io.techery.snapper.storage.StorageChange;
 
-public class MainThreadListenerProxy<T> implements IDataSet.Listener<T> {
+public class MainThreadDataListenerProxy<T> implements IDataSet.DataListener<T> {
 
     private final Handler handler;
-    private final WeakReference<IDataSet.Listener<T>> listenerRef;
+    private final WeakReference<IDataSet.DataListener<T>> listenerRef;
 
-    public MainThreadListenerProxy(IDataSet.Listener<T> listener) {
+    public MainThreadDataListenerProxy(IDataSet.DataListener<T> listener) {
         if (listener == null) {
             throw new IllegalArgumentException("Listener may not be null");
         }
-        listenerRef = new WeakReference<IDataSet.Listener<T>>(listener);
+        listenerRef = new WeakReference<IDataSet.DataListener<T>>(listener);
         handler = new Handler(Looper.getMainLooper());
     }
 
-    @Override public void onDataSetUpdated(final IDataSet<T> dataSet, final StorageChange<T> change) {
+    @Override public void onDataUpdated(final IDataSet<T> dataSet, final StorageChange<T> change) {
         handler.post(new Runnable() {
             @Override public void run() {
-                IDataSet.Listener<T> listener = listenerRef.get();
+                IDataSet.DataListener<T> listener = listenerRef.get();
                 if (listener != null) {
-                    listener.onDataSetUpdated(dataSet, change);
+                    listener.onDataUpdated(dataSet, change);
                 }
             }
         });

--- a/sample/src/main/java/com/example/snapper/MainActivity.java
+++ b/sample/src/main/java/com/example/snapper/MainActivity.java
@@ -52,9 +52,9 @@ public class MainActivity extends ActionBarActivity {
             }
         }).build();
 
-        sortedView.addListener(new IDataSet.Listener<User>() {
+        sortedView.addDataListener(new IDataSet.DataListener<User>() {
             @Override
-            public void onDataSetUpdated(IDataSet<User> dataSet, StorageChange<User> change) {
+            public void onDataUpdated(IDataSet<User> dataSet, StorageChange<User> change) {
                 if (dataSet.iterator().hasNext()) {
                     lastId = dataSet.iterator().next().getValue().id;
                 } else {


### PR DESCRIPTION
Every DataSet could be closed, so every child DataSet could notice it with StatusListener.
By default every child DataView is closed when parent is.
Snapper could be closed too, then every DataCollection is closed, but no the (snappy) db underlying instance.
In future we will close snappy db as well.

Tests include load test (made possible with close method)
